### PR TITLE
Add Context.invoking_prefix

### DIFF
--- a/src/niobot/commands.py
+++ b/src/niobot/commands.py
@@ -306,7 +306,13 @@ class Command:
             return self.callback(*parsed_args)
 
     def construct_context(
-        self, client: "NioBot", room: nio.MatrixRoom, src_event: nio.RoomMessageText, meta: str, cls: type = Context
+        self,
+        client: "NioBot",
+        room: nio.MatrixRoom,
+        src_event: nio.RoomMessageText,
+        invoking_prefix: str,
+        meta: str,
+        cls: type = Context,
     ) -> Context:
         """
         Constructs the context for the current command.
@@ -316,13 +322,14 @@ class Command:
         :param client: The current instance of the client.
         :param room: The room the command was invoked in.
         :param src_event: The source event that triggered the command. Must be `nio.RoomMessageText`.
+        :param invoking_prefix: The prefix that triggered the command.
         :param meta: The invoking string (usually the command name, however may be an alias instead)
         :param cls: The class to construct the context with. Defaults to `Context`.
         :return: The constructed Context.
         """
         if not isinstance(src_event, (nio.RoomMessageText, nio.RoomMessageNotice)):
             raise TypeError("src_event must be a textual event (i.e. m.text or m.notice).")
-        return cls(client, room, src_event, self, invoking_string=meta)
+        return cls(client, room, src_event, self, invoking_prefix=invoking_prefix, invoking_string=meta)
 
 
 def command(name: str = None, **kwargs) -> callable:

--- a/src/niobot/context.py
+++ b/src/niobot/context.py
@@ -83,6 +83,7 @@ class Context:
         event: nio.RoomMessageText,
         command: "Command",
         *,
+        invoking_prefix: typing.Optional[str] = None,
         invoking_string: str = None,
     ):
         self._init_ts = time.time()
@@ -90,8 +91,10 @@ class Context:
         self._room = room
         self._event = event
         self._command = command
+        self.invoking_prefix = invoking_prefix
         self._invoking_string = invoking_string
         to_parse = event.body
+
         if invoking_string:
             try:
                 to_parse = event.body[len(invoking_string) :]

--- a/src/niobot/utils/help_command.py
+++ b/src/niobot/utils/help_command.py
@@ -116,7 +116,7 @@ def get_long_description(command: "Command") -> str:
 async def default_help_command(ctx: "Context"):
     """Displays help text"""
     lines = []
-    prefix = ctx.invoking_prefix or "{prefix}"
+    prefix = ctx.invoking_prefix or "[p]"
     if not ctx.args:
         added = []
         # Display global help.

--- a/src/niobot/utils/help_command.py
+++ b/src/niobot/utils/help_command.py
@@ -116,6 +116,7 @@ def get_long_description(command: "Command") -> str:
 async def default_help_command(ctx: "Context"):
     """Displays help text"""
     lines = []
+    prefix = ctx.invoking_prefix or "{prefix}"
     if not ctx.args:
         added = []
         # Display global help.
@@ -123,7 +124,7 @@ async def default_help_command(ctx: "Context"):
         for command in ctx.client._commands.values():
             if command in added or command.disabled is True:
                 continue
-            display = format_command_line(ctx.client.command_prefix, command)
+            display = format_command_line(prefix, command)
             description = get_short_description(command)
             lines.append("* `{}`: {}".format(display, description))
             added.append(command)
@@ -133,7 +134,7 @@ async def default_help_command(ctx: "Context"):
         if not command:
             return await ctx.respond("No command with that name found!")
 
-        display = format_command_line(ctx.client.command_prefix, command)
+        display = format_command_line(prefix, command)
         description = get_long_description(command)
         lines = ["* {}:".format(display), *description.splitlines()]
         await ctx.respond(clean_output("\n".join(lines)))


### PR DESCRIPTION
This adds a `invoking_prefix` attribute of type `str | None` to the Context class.
It's content is the prefix used to invoke the command, if any.